### PR TITLE
#7 - 9/20: Authorization among microservices

### DIFF
--- a/identity-service/src/main/java/com/devteria/identity/configuration/AuthenticationRequestInterceptor.java
+++ b/identity-service/src/main/java/com/devteria/identity/configuration/AuthenticationRequestInterceptor.java
@@ -1,0 +1,23 @@
+package com.devteria.identity.configuration;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+public class AuthenticationRequestInterceptor implements RequestInterceptor {
+    @Override
+    public void apply(RequestTemplate template) {
+        ServletRequestAttributes servletRequestAttributes =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+        var authHeader = servletRequestAttributes.getRequest().getHeader("Authorization");
+
+        log.info("Header: {}", authHeader);
+        if (StringUtils.hasText(authHeader))
+            template.header("Authorization", authHeader);
+    }
+}

--- a/identity-service/src/main/java/com/devteria/identity/configuration/AuthenticationRequestInterceptor.java
+++ b/identity-service/src/main/java/com/devteria/identity/configuration/AuthenticationRequestInterceptor.java
@@ -7,6 +7,10 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+/**
+ * class config to add header when call api among microservice
+ * Note: not use @Bean to config because it only apply for some clients
+ */
 @Slf4j
 public class AuthenticationRequestInterceptor implements RequestInterceptor {
     @Override

--- a/identity-service/src/main/java/com/devteria/identity/repository/httpclient/ProfileClient.java
+++ b/identity-service/src/main/java/com/devteria/identity/repository/httpclient/ProfileClient.java
@@ -1,5 +1,6 @@
 package com.devteria.identity.repository.httpclient;
 
+import com.devteria.identity.configuration.AuthenticationRequestInterceptor;
 import com.devteria.identity.dto.request.ApiResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
@@ -9,8 +10,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import com.devteria.identity.dto.request.ProfileCreationRequest;
 import com.devteria.identity.dto.response.UserProfileResponse;
 
-@FeignClient(name = "profile-service", url = "${app.services.profile}")
+@FeignClient(name = "profile-service", url = "${app.services.profile}",
+        configuration = { AuthenticationRequestInterceptor.class })
 public interface ProfileClient {
     @PostMapping(value = "/internal/users", produces = MediaType.APPLICATION_JSON_VALUE)
     ApiResponse<UserProfileResponse> createProfile(@RequestBody ProfileCreationRequest request);
+
 }

--- a/identity-service/src/main/java/com/devteria/identity/repository/httpclient/ProfileClient.java
+++ b/identity-service/src/main/java/com/devteria/identity/repository/httpclient/ProfileClient.java
@@ -9,10 +9,15 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import com.devteria.identity.dto.request.ProfileCreationRequest;
 import com.devteria.identity.dto.response.UserProfileResponse;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(name = "profile-service", url = "${app.services.profile}",
         configuration = { AuthenticationRequestInterceptor.class })
 public interface ProfileClient {
+    // C1
+//    @PostMapping(value = "/internal/users", produces = MediaType.APPLICATION_JSON_VALUE)
+//    ApiResponse<UserProfileResponse> createProfile(@RequestHeader("Authorization") String token, @RequestBody ProfileCreationRequest request);
+
     @PostMapping(value = "/internal/users", produces = MediaType.APPLICATION_JSON_VALUE)
     ApiResponse<UserProfileResponse> createProfile(@RequestBody ProfileCreationRequest request);
 

--- a/identity-service/src/main/java/com/devteria/identity/service/UserService.java
+++ b/identity-service/src/main/java/com/devteria/identity/service/UserService.java
@@ -26,6 +26,8 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Service
 @RequiredArgsConstructor

--- a/identity-service/src/main/java/com/devteria/identity/service/UserService.java
+++ b/identity-service/src/main/java/com/devteria/identity/service/UserService.java
@@ -56,6 +56,12 @@ public class UserService {
         var profileRequest = profileMapper.toProfileCreationRequest(request);
         profileRequest.setUserId(user.getId());
 
+        // C1: boiler code
+//        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+//        var authHeader = attributes.getRequest().getHeader("Authorization");
+//        log.info("Header: {}", authHeader);
+//        profileClient.createProfile(authHeader, profileRequest);
+
         profileClient.createProfile(profileRequest);
 
         return userMapper.toUserResponse(user);


### PR DESCRIPTION
- Mặc định ko truyền token là unauthen, ngoại trừ các endpoint đã config permitAll. Khi truyền token qua thì nếu parse thông tin lỗi cũng tính là unauthen
- Khi các service gọi lẫn nhau thì không cần quan tâm authen nữa vì đã xác thực không qua gateway
, chỉ cần quan tâm authorization
- Có 2 cách để add header Authorization vào FeignClient: 1 tự thêm header vào mỗi khi call, 2 là dùng Interceptor để add global
- Không config là @Bean vì nó sẽ apply toàn bộ cho FeignClient mà thay vào đó Client nào dùng thì add class config đó vào